### PR TITLE
downloadFromData demo gives weird output

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -51,7 +51,7 @@
                   createFile() {
                     const data = 'firstname, middlename, lastname, address_number, address_street, address_city, address_state, address_zip, is_cool\n' +
                     'Jimmy, Jack, Awesome, 4242, Pendleton Ave, Saint Louis, MO, 63132, true';
-                    this.downloadFromData(data, 'text/csv', 'sample.csv');
+                    this.downloadFromData(data, 'csv', 'sample');
                   }
                 });
               });


### PR DESCRIPTION
![2017-12-10_10-06-07](https://user-images.githubusercontent.com/329735/33806204-70d4f17e-dd92-11e7-92d4-80b39eadcb80.png)

The current example gives something like this -

when really you don't need the mime type, just file type. And you don't need the extension, it does that for you.